### PR TITLE
Update Docs/Setup.MD

### DIFF
--- a/Docs/Setup.MD
+++ b/Docs/Setup.MD
@@ -159,10 +159,6 @@ ln -s /usr/local/lib/liblirc_client.so.0.2.1 /usr/local/lib/liblirc_client.so
 
 ldconfig
 
-#set keyboard layout (may not be needed)
-apt-get install keyboard-configuration
-#select layout then select ok
-
 # Set locale to c to prevent weird characters in xbian-config and c compiling
 dpkg-reconfigure locales
 #First window select ok
@@ -197,7 +193,6 @@ rm /var/swap
 rm -rf /home/xbian/source
 
 #Add apt sources
-#Example [aptsource] is apt.xbian.org
 echo "deb http://[aptsource]/ wheezy main" >> /etc/apt/sources.list
 wget -O - http://[aptsource]/xbian.gpg.key | apt-key add -
 apt-get update 


### PR DESCRIPTION
The instructions weren't working for me so I made a few small changes.
 I put the xbian user setup at the top because otherwise the "dpkg -L libraspberrypi0 > /home/xbian/list" commands wouldn't work. mkdir /home/xbian fixed the problem without first creating the user but then when setting up the user later it had a warning because the user folder was already there and saying it didn't copy over some other folder (not sure if it matters or not)
 The keyboard layout was set to UK or something because when I pressed \ it would type #. I ran apt-get install keyboard-configuration and selected US and it works now, but thinking about it that may have been because I rebooted.

I'm a bit of a n00b when it comes to linux so I may have got some things wrong.
