### PR TITLE
Fixed lirc script errors when MCE device is connected

### DIFF
--- a/etc/lirc/hardware.conf
+++ b/etc/lirc/hardware.conf
@@ -50,12 +50,12 @@ if [ -z $LIRCD_ARGS ] && [ $START_LIRCMD ] && [ $START_IREXEC ] && [ -z $LOAD_MO
 		modprobe -r rc_core
 		sleep 2;
 	elif [ $(echo $DMESG | grep mceusb | wc -l) -gt 0 ]; then
-		if [ $(echo $DEVICES | grep 'Media Center Ed.' | wc -l) -gt 0 ]; then
-			if [ $(echo $DEVICES | grep -m 1 -A 4 'Media Center Ed.' | grep -o event[0-9] | sed -e 's/event//g') -eq 0 ]; then
+		if [ $(echo "$DEVICES" | grep 'Media Center Ed.' | wc -l) -gt 0 ]; then
+			if [ $(echo "$DEVICES" | grep -m 1 -A 4 'Media Center Ed.' | grep -o event[0-9] | sed -e 's/event//g') -eq 0 ]; then
 				. /etc/lirc/hardware/mceusb_event0.conf
-			elif [ $(echo $DEVICES | grep -m 1 -A 4 'Media Center Ed.' | grep -o event[0-9] | sed -e 's/event//g') -eq 1 ]; then
+			elif [ $(echo "$DEVICES" | grep -m 1 -A 4 'Media Center Ed.' | grep -o event[0-9] | sed -e 's/event//g') -eq 1 ]; then
 				. /etc/lirc/hardware/mceusb_event1.conf
-			elif [ $(echo $DEVICES | grep -m 1 -A 4 'Media Center Ed.' | grep -o event[0-9] | sed -e 's/event//g') -eq 2 ]; then
+			elif [ $(echo "$DEVICES" | grep -m 1 -A 4 'Media Center Ed.' | grep -o event[0-9] | sed -e 's/event//g') -eq 2 ]; then
 				. /etc/lirc/hardware/mceusb_event2.conf
 			else
 				. /etc/lirc/hardware/mceusb.conf
@@ -64,12 +64,12 @@ if [ -z $LIRCD_ARGS ] && [ $START_LIRCMD ] && [ $START_IREXEC ] && [ -z $LOAD_MO
 			. /etc/lirc/hardware/mceusb.conf
 		fi 
 	elif [ $(echo $DMESG | grep "MCE USB IR Receiver- Spinel plus" | wc -l) -gt 0 ]; then
-		if [ $(echo $DEVICES | grep 'MCE USB IR Receiver- Spinel plus' | wc -l) -gt 0 ]; then
-			if [ $(echo $DEVICES | grep -m 1 -A 4 'MCE USB IR Receiver- Spinel plus' | grep -o event[0-9] | sed -e 's/event//g') -eq 0 ]; then
+		if [ $(echo "$DEVICES" | grep 'MCE USB IR Receiver- Spinel plus' | wc -l) -gt 0 ]; then
+			if [ $(echo "$DEVICES" | grep -m 1 -A 4 'MCE USB IR Receiver- Spinel plus' | grep -o event[0-9] | sed -e 's/event//g') -eq 0 ]; then
 				. /etc/lirc/hardware/mceusb_event0.conf
-			elif [ $(echo $DEVICES | grep -m 1 -A 4 'MCE USB IR Receiver- Spinel plus' | grep -o event[0-9] | sed -e 's/event//g') -eq 1 ]; then
+			elif [ $(echo "$DEVICES" | grep -m 1 -A 4 'MCE USB IR Receiver- Spinel plus' | grep -o event[0-9] | sed -e 's/event//g') -eq 1 ]; then
 				. /etc/lirc/hardware/mceusb_event1.conf
-			elif [ $(echo $DEVICES | grep -m 1 -A 4 'MCE USB IR Receiver- Spinel plus' | grep -o event[0-9] | sed -e 's/event//g') -eq 2 ]; then
+			elif [ $(echo "$DEVICES" | grep -m 1 -A 4 'MCE USB IR Receiver- Spinel plus' | grep -o event[0-9] | sed -e 's/event//g') -eq 2 ]; then
 				. /etc/lirc/hardware/mceusb_event2.conf
 			else
 				. /etc/lirc/hardware/mceusb.conf


### PR DESCRIPTION
The DEVICES variable must be quoted to preserve newlines in its content.
Without them everything is squashed down to a single line, and every 'eventN'
device is returned in the grep output, instead of just the MCE device.  This
lead to syntax errors in the test expressions on every lircd start/stop.
