### PR TITLE
JFS formatted disk auto-mounting

### DIFF
--- a/splitted. browse into xbian-* repositories for sources/usbmount/usbmount.conf
+++ b/splitted. browse into xbian-* repositories for sources/usbmount/usbmount.conf
@@ -35,7 +35,7 @@ FILESYSTEMS="ntfs vfat ext2 ext3 ext4 hfsplus exfat jfs"
 #############################################################################
 # Mount options: Options passed to the mount command with the -o flag.
 # See the warning above regarding removing "sync" from the options.
-MOUNTOPTIONS="sync,noexec,nodev,noatime,nodiratime,rw"
+MOUNTOPTIONS="sync,noexec,nodev,noatime,rw"
 
 # Filesystem type specific mount options: This variable contains a space
 # separated list of strings, each which the form "-fstype=TYPE,OPTIONS".


### PR DESCRIPTION
Recently I switched from Raspbmc to XBian. On Raspbmc I've been using a 2TB disk formatted with the JFS filesystem for almost 2 years now without any problems. Unfortunately XBian did not mount my disk automatically, so I looked into fixing that.
Fix proved to be very easy: The JFS filesystem was not added to the FILESYSTEMS line. After adding it, the disk auto-mounted perfectly and has been working great ever since. 

I also took out a redundant "nodiratime", because the "noatime" option implies "nodiratime".
