### PR TITLE
Added a post-build.d hook

### DIFF
--- a/build.package
+++ b/build.package
@@ -84,6 +84,8 @@ do_make()
     else
         ( rexp ../env; do_run $config_build_env $config_build_make; )
     fi
+
+    do_hooks post-build.d
 }
 
 do_patch()


### PR DESCRIPTION
The ZFS and SPL kernel modules can only be compiled once the kernel itself is done building. Therefor an additional post-build hook is needed.
