### PR TITLE
lsb-release should be installed first

### DIFF
--- a/xbian-prep-root/build/config
+++ b/xbian-prep-root/build/config
@@ -1,3 +1,3 @@
-config_deb_base=libltdl-dev dpkg-dev git debootstrap autoconf automake swig doxygen libtool autopoint pkg-config lzop openjdk-7-jre-headless openjdk-6-jre-headless- openjdk-6-jre- qemu-user-static schroot kpartx parted btrfs-tools dosfstools u-boot-tools coreutils
+config_deb_base=libltdl-dev dpkg-dev git debootstrap autoconf automake swig doxygen libtool autopoint pkg-config lzop openjdk-7-jre-headless openjdk-6-jre-headless- openjdk-6-jre- qemu-user-static schroot kpartx parted btrfs-tools dosfstools u-boot-tools coreutils lsb-release
 config_root_prefix=
 config_wrapper=create.buildroot


### PR DESCRIPTION
xbian-package-repo depends on lsb-release to set the right repository, therefor it should be installed at the debootstrap setup.
