### PR TITLE
Changed from sfdisk to fdisk

### DIFF
--- a/build.img
+++ b/build.img
@@ -65,11 +65,32 @@ do_img()
     fi
     if [ -z "$config_fstype_boot" ]; then
 #        echo "71680,+,83,," | sfdisk -u S -N1 -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1
-        echo "$config_offset_root,+,83,," | sfdisk -u S -N1 -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1
+        fdisk $IMGNAME <<EOF > /dev/null 2>&1
+n
+p
+1
+$config_offset_root
+
+w
+EOF
     else
 #        echo "71680,+,83,," | sfdisk -u S -N2 -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1
-        echo "2048,$((config_offset_root-2048)),b,*," | sfdisk -u S -N1 -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1
-        echo "$config_offset_root,+,83,," | sfdisk -u S -N2 -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1
+        fdisk $IMGNAME <<EOF > /dev/null 2>&1
+n
+p
+1
+2048
+$((config_offset_root-1))
+t
+b
+a
+n
+p
+2
+
+
+w
+EOF
     fi
 
     [ -d /run ] || mkdir /run

--- a/xbian-build-img/hooks.d/post-img.d/resize-part-btrfs
+++ b/xbian-build-img/hooks.d/post-img.d/resize-part-btrfs
@@ -31,7 +31,17 @@ umount ./rootfs; sync
 newpartsize=$(dmesg | grep -i "new size" | grep "/dev/mapper/${loopd}p${rootpart}\|/dev/dm" | tail -1 | awk '{print $NF}')
 newpartsize=$((newpartsize/512+64))
 kpartx -dv $IMGNAME
-echo ",$newpartsize,,," | sfdisk -u S -N${rootpart} -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1; sync
+fdisk $IMGNAME <<EOF
+d
+$rootpart
+n
+p
+2
+
+$newpartsize
+w
+EOF
+sync
 
 newimgsize=$((newpartsize+141312))
 dd if=$IMGNAME of=$IMGNAME.new bs=512 count=$newimgsize

--- a/xbian-build-img/hooks.d/post-img.d/resize-part-ext4
+++ b/xbian-build-img/hooks.d/post-img.d/resize-part-ext4
@@ -17,7 +17,17 @@ newpartsize=$((config_img_size+20))
 df -h | grep /working/
 umount ./rootfs; sync
 kpartx -dv $IMGNAME
-echo ",$newpartsize,,," | sfdisk -u S -N2 -H 4 -S 16 -q $IMGNAME > /dev/null 2>&1; sync
+fdisk $IMGNAME <<EOF >/dev/null 2>&1
+d
+2
+n
+p
+2
+
+$newpartsize
+w
+EOF
+sync
 
 newimgsize=$((newpartsize+141312))
 dd if=$IMGNAME of=$IMGNAME.new bs=512 count=$newimgsize


### PR DESCRIPTION
I tried to run "$xbiangit --arch rpi3 --action build" under the new ubuntu 16.04 (xenial/amd64), but it failed because of a new version of sfdisk, which is not compatible with the script. I changed the scripts to use fdisk instead of sfdisk and it works.